### PR TITLE
Fix bug & Update README.md

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
     branches: [ master ]
   schedule:
     - cron: '0 1 * * *'
+permissions: write-all
 jobs:
   build:
     name: Suying666-clock-in by GitHub Actions
@@ -27,12 +28,17 @@ jobs:
           PASSWD: ${{ secrets.PASSWD }}
           KEY: ${{ secrets.KEY }}
 
-      - name: 4. update github repository...
+      - name: 4. commit...
         run: |
           git config --global user.email "$EMAIL"
           git config --global user.name "bot"
           git add .
           git commit -m "auto-update"
-          git push -f
         env:
           EMAIL: ${{ secrets.EMAIL }}
+
+      - name: 5. push changes to repository...
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: master

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@
     - EMAIL 是suying666的账号
     - PASSWD 是suying666的密码
     - KEY是server酱的key，获取key参考[server酱官方说明](http://sc.ftqq.com/3.version)
-3. UTC时间的每天01:00分（北京时间：09:00，并不准时），github actions会自动帮助您签到领取流量，如果您配置了server酱的key的话，您将收到微信消息通知
-4. enjoy it!!!
+3. 先在Actions页面将GitHub Action启用，再选择对应的workflow，将scheduled workflow启用
+   ![enable-schedule-workflow](https://user-images.githubusercontent.com/90035785/224888848-be15ba52-1892-4a2b-9cef-b321b9a25165.jpg)
+4. UTC时间的每天01:00分（北京时间：09:00，并不准时），github actions会自动帮助您签到领取流量，如果您配置了server酱的key的话，您将收到微信消息通知
+5. enjoy it!!!
 
 # 特性
 


### PR DESCRIPTION
2021.8.13起，GitHub要求使用基于令牌的身份验证，密码验证将不被支持，详见
https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations

我已经尝试过使用原仓库的Actions，在`git push -f`时会报错403 Forbidden
因此我修改了`build.yml`，使用了`GITHUB_TOKEN`作为认证方法，并且已经调试完毕

此外，GitHub现在默认会关闭Action的定时任务，需要手动将其打开，我也在README.md中添加了相关说明
![enable-schedule-workflow](https://user-images.githubusercontent.com/90035785/224888848-be15ba52-1892-4a2b-9cef-b321b9a25165.jpg)